### PR TITLE
preg_replace untaints a string

### DIFF
--- a/tests/020.phpt
+++ b/tests/020.phpt
@@ -1,0 +1,17 @@
+--TEST--
+preg_replace() untaints a string
+--SKIPIF--
+<?php if (!extension_loaded("taint")) print "skip"; ?>
+--INI--
+taint.enable=1
+--FILE--
+<?php
+$query = "SELECT * FROM ..".".";
+taint($query); //must use concat to make the string not a internal string(introduced in 5.4)
+var_dump(is_tainted($query));
+
+$query = preg_replace('{^\s*SELECT}i', 'SELECT/*', $query, 1);
+var_dump(is_tainted($query));
+--EXPECTF--
+bool(true)
+bool(true)

--- a/tests/020.phpt
+++ b/tests/020.phpt
@@ -14,4 +14,4 @@ $query = preg_replace('{^\s*SELECT}i', 'SELECT/*', $query, 1);
 var_dump(is_tainted($query));
 --EXPECTF--
 bool(true)
-bool(true)
+bool(false)

--- a/tests/021.phpt
+++ b/tests/021.phpt
@@ -1,0 +1,27 @@
+--TEST--
+preg_replace() should untaint a string
+--SKIPIF--
+<?php if (!extension_loaded("taint")) print "skip"; ?>
+--INI--
+taint.enable=1
+--FILE--
+<?php
+class request {
+    function get() {
+        $a = "a" ."";
+        taint($a);
+        
+        return $a;    
+    }
+}
+
+$req = new request();
+var_dump(is_tainted($req->get()));
+
+$a = preg_replace('/[^a-z_\-]/i', '', $req->get());
+
+var_dump(is_tainted($a));
+--EXPECTF--
+bool(true)
+bool(false)
+


### PR DESCRIPTION
~~per docs on http://php.net/manual/de/taint.detail.untaint.php a `preg_replace`  should not untained a string.~~

this PR adds a failing test, which I expect to succeed.