### PR TITLE
fix build with PHP 7.0

### DIFF
--- a/php_taint.h
+++ b/php_taint.h
@@ -65,6 +65,7 @@ extern zend_module_entry taint_module_entry;
 #define TAINT_OP2_TYPE(opline)	(opline->op2_type)
 
 #if PHP_VERSION_ID < 70100
+#define PHP_7_0 1
 #define TAINT_RET_USED(opline) (!((opline)->result_type & EXT_TYPE_UNUSED))
 #define TAINT_ISERR(var)       (var == &EG(error_zval))
 #define TAINT_ERR_ZVAL(var)    (var = &EG(error_zval))


### PR DESCRIPTION
Without this patch
```

BUILDSTDERR: /builddir/build/BUILD/php70-php-pecl-taint-2.0.5/NTS/taint.c: In function 'php_taint_fetch_dimension_address':
BUILDSTDERR: /builddir/build/BUILD/php70-php-pecl-taint-2.0.5/NTS/taint.c:292:5: warning: implicit declaration of function 'ZVAL_ERROR'; did you mean 'DL_ERROR'? [-Wimplicit-functi
on-declaration]
BUILDSTDERR:      ZVAL_ERROR(result);
BUILDSTDERR:      ^~~~~~~~~~
BUILDSTDERR:      DL_ERROR

```

And trying to load the extension:
`PHP Warning:  PHP Startup: Unable to load dynamic library .../modules/taint.so: undefined symbol: ZVAL_ERROR in Unknown on line 0`

I notice the compat macro `TAINT_ERR_ZVAL`, but doesn't seem usable