### PR TITLE
docs: fix simple typo, agianst -> against

### DIFF
--- a/php_taint.h
+++ b/php_taint.h
@@ -36,7 +36,7 @@ extern zend_module_entry taint_module_entry;
 
 /* it's important that make sure 
  * this value is not used by Zend or
- * any other extension agianst string */
+ * any other extension against string */
 #define IS_STR_TAINT_POSSIBLE    (1<<7)
 
 #if PHP_VERSION_ID >= 70000


### PR DESCRIPTION
There is a small typo in php_taint.h.

Should read `against` rather than `agianst`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md